### PR TITLE
Add Flutter moon phase application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-"# moon-app" 
+# Moon App
+
+A Flutter application that displays the current moon phase, illumination percentage, and upcoming phase. It features a dynamic moon, starfield animation, and a dark space-inspired theme.
+
+## Getting Started
+
+1. Ensure [Flutter](https://flutter.dev) is installed.
+2. Run `flutter pub get` to fetch dependencies.
+3. Launch the app with `flutter run`.
+
+Replace the placeholder font in `assets/fonts/` with a real font for production use.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'services/moon_service.dart';
+import 'viewmodels/moon_view_model.dart';
+import 'views/home_view.dart';
+
+void main() {
+  runApp(const MoonApp());
+}
+
+class MoonApp extends StatelessWidget {
+  const MoonApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => MoonViewModel(MoonService())..fetchMoon(),
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData.dark().copyWith(
+          scaffoldBackgroundColor: Colors.black,
+          textTheme: ThemeData.dark().textTheme.apply(fontFamily: 'SpaceMono'),
+        ),
+        home: const HomeView(),
+      ),
+    );
+  }
+}

--- a/lib/models/moon_data.dart
+++ b/lib/models/moon_data.dart
@@ -1,0 +1,22 @@
+class MoonData {
+  final String phase;
+  final double illumination;
+  final String nextPhase;
+  final DateTime nextPhaseDate;
+
+  MoonData({
+    required this.phase,
+    required this.illumination,
+    required this.nextPhase,
+    required this.nextPhaseDate,
+  });
+
+  factory MoonData.fromJson(Map<String, dynamic> json) {
+    return MoonData(
+      phase: json['Phase'] ?? '',
+      illumination: double.tryParse(json['Illumination'].toString()) ?? 0,
+      nextPhase: json['NextPhase'] ?? '',
+      nextPhaseDate: DateTime.tryParse(json['NextPhaseDate'] ?? '') ?? DateTime.now(),
+    );
+  }
+}

--- a/lib/services/moon_service.dart
+++ b/lib/services/moon_service.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../models/moon_data.dart';
+import '../utils/constants.dart';
+
+class MoonService {
+  static const _baseUrl = 'https://api.farmsense.net/v1/moonphases/?d=';
+
+  Future<MoonData> fetchMoonData() async {
+    final now = DateTime.now();
+    final response = await http.get(Uri.parse('$_baseUrl${now.millisecondsSinceEpoch ~/ 1000}'));
+    if (response.statusCode != 200) {
+      throw Exception('Failed to fetch moon data');
+    }
+    final List<dynamic> body = jsonDecode(response.body);
+    final data = body.first as Map<String, dynamic>;
+    final phase = data['Phase'] ?? '';
+    final illumination = double.tryParse(data['Illumination'].toString()) ?? 0;
+    final nextInfo = await _findNextPhase(now, phase);
+    return MoonData(
+      phase: phase,
+      illumination: illumination,
+      nextPhase: nextInfo['phase'] as String,
+      nextPhaseDate: nextInfo['date'] as DateTime,
+    );
+  }
+
+  Future<Map<String, dynamic>> _findNextPhase(DateTime start, String currentPhase) async {
+    DateTime date = start.add(const Duration(days: 1));
+    while (true) {
+      final response = await http.get(Uri.parse('$_baseUrl${date.millisecondsSinceEpoch ~/ 1000}'));
+      if (response.statusCode != 200) break;
+      final List<dynamic> body = jsonDecode(response.body);
+      final data = body.first as Map<String, dynamic>;
+      final phase = data['Phase'] ?? '';
+      if (phase != currentPhase) {
+        return {
+          'phase': phase,
+          'date': date,
+        };
+      }
+      date = date.add(const Duration(days: 1));
+    }
+    final index = kPhases.indexOf(currentPhase);
+    final nextIndex = (index + 1) % kPhases.length;
+    return {
+      'phase': kPhases[nextIndex],
+      'date': date,
+    };
+  }
+}

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+const List<String> kPhases = [
+  'New Moon',
+  'Waxing Crescent',
+  'First Quarter',
+  'Waxing Gibbous',
+  'Full Moon',
+  'Waning Gibbous',
+  'Last Quarter',
+  'Waning Crescent',
+];
+
+const Map<String, String> kPhaseEmojis = {
+  'New Moon': '🌑',
+  'Waxing Crescent': '🌒',
+  'First Quarter': '🌓',
+  'Waxing Gibbous': '🌔',
+  'Full Moon': '🌕',
+  'Waning Gibbous': '🌖',
+  'Last Quarter': '🌗',
+  'Waning Crescent': '🌘',
+};
+
+final Gradient kBackgroundGradient = const LinearGradient(
+  begin: Alignment.topCenter,
+  end: Alignment.bottomCenter,
+  colors: [Color(0xFF000428), Color(0xFF004e92)],
+);

--- a/lib/viewmodels/moon_view_model.dart
+++ b/lib/viewmodels/moon_view_model.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import '../models/moon_data.dart';
+import '../services/moon_service.dart';
+
+class MoonViewModel extends ChangeNotifier {
+  final MoonService _service;
+
+  MoonData? _data;
+  bool _loading = false;
+  String? _error;
+
+  MoonData? get data => _data;
+  bool get isLoading => _loading;
+  String? get error => _error;
+
+  MoonViewModel(this._service);
+
+  Future<void> fetchMoon() async {
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _data = await _service.fetchMoonData();
+    } catch (e) {
+      _error = e.toString();
+    }
+    _loading = false;
+    notifyListeners();
+  }
+}

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../utils/constants.dart';
+import '../viewmodels/moon_view_model.dart';
+import '../widgets/moon_widget.dart';
+import '../widgets/starfield_widget.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class HomeView extends StatelessWidget {
+  const HomeView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = Provider.of<MoonViewModel>(context);
+
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: Container(
+        decoration: const BoxDecoration(gradient: kBackgroundGradient),
+        child: Stack(
+          children: [
+            const Positioned.fill(child: StarfieldWidget()),
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    if (vm.isLoading) const CircularProgressIndicator(),
+                    if (vm.error != null) Text(vm.error!),
+                    if (vm.data != null) ...[
+                      MoonWidget(illumination: vm.data!.illumination),
+                      const SizedBox(height: 16),
+                      Text(
+                        '${kPhaseEmojis[vm.data!.phase] ?? ''} ${vm.data!.phase}',
+                        style: GoogleFonts.spaceMono(
+                          fontSize: 24,
+                          color: Colors.white,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Illumination: ${vm.data!.illumination.toStringAsFixed(1)}%',
+                        style: GoogleFonts.spaceMono(color: Colors.white70),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Next: ${vm.data!.nextPhase} on ${vm.data!.nextPhaseDate.toLocal().toString().split(' ').first}',
+                        style: GoogleFonts.spaceMono(color: Colors.white70),
+                      ),
+                    ],
+                    const SizedBox(height: 24),
+                    ElevatedButton.icon(
+                      onPressed: vm.fetchMoon,
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('Refresh'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/moon_widget.dart
+++ b/lib/widgets/moon_widget.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+class MoonWidget extends StatelessWidget {
+  final double illumination; // 0-100
+  const MoonWidget({super.key, required this.illumination});
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 600),
+      curve: Curves.easeInOut,
+      width: 200,
+      height: 200,
+      child: CustomPaint(
+        painter: _MoonPainter(illumination / 100),
+      ),
+    );
+  }
+}
+
+class _MoonPainter extends CustomPainter {
+  final double value; // 0-1
+  _MoonPainter(this.value);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.width / 2;
+    final paint = Paint()..color = Colors.white;
+    canvas.drawCircle(center, radius, paint);
+
+    final clipPath = Path();
+    if (value < 0.5) {
+      final theta = (1 - (value * 2)) * 3.14159;
+      clipPath.addOval(Rect.fromCircle(center: center, radius: radius));
+      canvas.saveLayer(Rect.fromLTWH(0, 0, size.width, size.height), Paint());
+      canvas.drawCircle(center, radius, paint);
+      paint.blendMode = BlendMode.dstOut;
+      canvas.drawArc(Rect.fromCircle(center: center, radius: radius),
+          -3.14159 / 2, theta, true, paint);
+      canvas.restore();
+    } else {
+      final theta = ((value - 0.5) * 2) * 3.14159;
+      clipPath.addOval(Rect.fromCircle(center: center, radius: radius));
+      canvas.saveLayer(Rect.fromLTWH(0, 0, size.width, size.height), Paint());
+      canvas.drawCircle(center, radius, paint);
+      paint.color = Colors.black;
+      canvas.drawArc(Rect.fromCircle(center: center, radius: radius),
+          3.14159 / 2, theta, true, paint);
+      canvas.restore();
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _MoonPainter oldDelegate) => oldDelegate.value != value;
+}

--- a/lib/widgets/starfield_widget.dart
+++ b/lib/widgets/starfield_widget.dart
@@ -1,0 +1,75 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+
+class StarfieldWidget extends StatefulWidget {
+  const StarfieldWidget({super.key});
+
+  @override
+  State<StarfieldWidget> createState() => _StarfieldWidgetState();
+}
+
+class _StarfieldWidgetState extends State<StarfieldWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  final Random _random = Random();
+  final List<_Star> _stars = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: const Duration(seconds: 20))
+      ..addListener(() => setState(() {}))
+      ..repeat();
+    for (int i = 0; i < 100; i++) {
+      _stars.add(_Star(
+        x: _random.nextDouble(),
+        y: _random.nextDouble(),
+        size: _random.nextDouble() * 2 + 1,
+        speed: _random.nextDouble() * 0.0005 + 0.0002,
+      ));
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _StarfieldPainter(_stars, _controller.value),
+      child: const SizedBox.expand(),
+    );
+  }
+}
+
+class _Star {
+  double x;
+  double y;
+  double size;
+  double speed;
+
+  _Star({required this.x, required this.y, required this.size, required this.speed});
+}
+
+class _StarfieldPainter extends CustomPainter {
+  final List<_Star> stars;
+  final double animationValue;
+
+  _StarfieldPainter(this.stars, this.animationValue);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = Colors.white.withOpacity(0.8);
+    for (final star in stars) {
+      final dx = star.x * size.width;
+      final dy = (star.y + animationValue * star.speed * size.height) % size.height;
+      canvas.drawCircle(Offset(dx, dy), star.size, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _StarfieldPainter oldDelegate) => true;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,22 @@
+name: moon_app
+description: A beautiful Flutter app showing real-time moon phase information.
+version: 1.0.0
+
+environment:
+  sdk: '>=2.19.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.13.6
+  provider: ^6.0.5
+  google_fonts: ^4.0.4
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/images/
+  fonts:
+    - family: SpaceMono
+      fonts:
+        - asset: assets/fonts/SpaceMono-Regular.ttf


### PR DESCRIPTION
## Summary
- add a Flutter app skeleton using MVVM with provider
- implement moon phase service, view model, and UI
- draw the moon with a custom painter
- add starfield background animation and dark theme
- include placeholder font and update README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f5b2aa6c8327820ace36339056ca